### PR TITLE
add the fix for CVE-2019-11254

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -5,9 +5,9 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Recently the dependabot reported me that one of my project is affected by [CVE-2019-11254](https://nvd.nist.gov/vuln/detail/CVE-2019-11254) due to this module gopkg.in/yaml.v2@v2.2.2. The investigation leaded me in this repo. Regardless this CVE has medium score I'd like to propose this PR with fix.

**Details and proofs:**
I am using the latest github.com/didip/tollbooth/v6@v6.1.2 ->
that is using your the latest module expirable-cache@v0.0.3 ->
that is using github.com/stretchr/testify@v1.5.1 ->
that is using gopkg.in/yaml.v2 v2.2.2 which contains this vulnerability.

The prints of "go mod graph" you can find below:

->_go mod graph | grep testify@v1.5.1_ 

**github.com/go-pkgz/expirable-cache@v0.0.3 github.com/stretchr/testify@v1.5.1**
github.com/stretchr/testify@v1.5.1 github.com/davecgh/go-spew@v1.1.0
github.com/stretchr/testify@v1.5.1 github.com/pmezard/go-difflib@v1.0.0
github.com/stretchr/testify@v1.5.1 github.com/stretchr/objx@v0.1.0
**github.com/stretchr/testify@v1.5.1 gopkg.in/yaml.v2@v2.2.2**

->_go mod graph | grep expirable-cache_

**github.com/didip/tollbooth/v6@v6.1.2 github.com/go-pkgz/expirable-cache@v0.0.3**
github.com/go-pkgz/expirable-cache@v0.0.3 github.com/pkg/errors@v0.9.1
**github.com/go-pkgz/expirable-cache@v0.0.3 github.com/stretchr/testify@v1.5.1**

P.S.
I understand that I will get this fix only when expirable-cache is upgraded in github.com/didip/tollbooth/v6
