### PR TITLE
Rewrite v3 time-dependent tests with testing/synctest

### DIFF
--- a/.github/workflows/ci-v3.yml
+++ b/.github/workflows/ci-v3.yml
@@ -23,7 +23,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.25"
           cache-dependency-path: v3/go.sum
         id: go
 

--- a/v3/cache_expire_synctest_test.go
+++ b/v3/cache_expire_synctest_test.go
@@ -1,0 +1,108 @@
+//go:build go1.25
+
+package cache
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheWithDeleteExpired(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var evicted []string
+		lc := NewCache[string, string]().WithTTL(time.Second * 15).WithOnEvicted(
+			func(key string, value string) {
+				evicted = append(evicted, key, value)
+			})
+
+		lc.Set("key1", "val1", 0)
+
+		time.Sleep(time.Second * 10) // not enough to expire
+		lc.DeleteExpired()
+		assert.Equal(t, 1, lc.Len())
+
+		v, ok := lc.Get("key1")
+		assert.Equal(t, "val1", v)
+		assert.True(t, ok)
+
+		time.Sleep(time.Second * 20) // expire
+		lc.DeleteExpired()
+		v, ok = lc.Get("key1")
+		assert.False(t, ok)
+		assert.Equal(t, "", v)
+
+		assert.Equal(t, 0, lc.Len())
+		assert.Equal(t, []string{"key1", "val1"}, evicted)
+
+		// add new entry
+		lc.Set("key2", "val2", 0)
+		assert.Equal(t, 1, lc.Len())
+
+		// nothing deleted
+		lc.DeleteExpired()
+		assert.Equal(t, 1, lc.Len())
+		assert.Equal(t, []string{"key1", "val1"}, evicted)
+
+		// Purge, cache should be clean
+		lc.Purge()
+		assert.Equal(t, 0, lc.Len())
+		assert.Equal(t, []string{"key1", "val1", "key2", "val2"}, evicted)
+	})
+}
+
+func TestCacheExpired(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		lc := NewCache[string, string]().WithTTL(time.Second * 5)
+
+		lc.Set("key1", "val1", 0)
+		assert.Equal(t, 1, lc.Len())
+
+		v, ok := lc.Peek("key1")
+		assert.Equal(t, v, "val1")
+		assert.True(t, ok)
+
+		v, ok = lc.Get("key1")
+		assert.Equal(t, v, "val1")
+		assert.True(t, ok)
+
+		time.Sleep(time.Second * 10) // wait for entry to expire
+		assert.Equal(t, 1, lc.Len()) // but not purged
+
+		v, ok = lc.Peek("key1")
+		assert.Equal(t, "val1", v, "expired and marked as such, but value is available")
+		assert.False(t, ok)
+
+		v, ok = lc.Get("key1")
+		assert.Equal(t, "val1", v, "expired and marked as such, but value is available")
+		assert.False(t, ok)
+
+		assert.Empty(t, lc.Values())
+	})
+}
+
+func TestCache_GetExpiration(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		lc := NewCache[string, string]().WithTTL(time.Second * 5)
+
+		lc.Set("key1", "val1", time.Second*5)
+		assert.Equal(t, 1, lc.Len())
+
+		exp, ok := lc.GetExpiration("key1")
+		assert.True(t, ok)
+		assert.Equal(t, time.Now().Add(time.Second*5), exp)
+
+		lc.Set("key2", "val2", time.Second*10)
+		assert.Equal(t, 2, lc.Len())
+
+		exp, ok = lc.GetExpiration("key2")
+		assert.True(t, ok)
+		assert.Equal(t, time.Now().Add(time.Second*10), exp)
+
+		exp, ok = lc.GetExpiration("non-existing-key")
+		assert.False(t, ok)
+		assert.Zero(t, exp)
+	})
+}

--- a/v3/cache_expire_test.go
+++ b/v3/cache_expire_test.go
@@ -1,0 +1,103 @@
+//go:build !go1.25
+
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheWithDeleteExpired(t *testing.T) {
+	var evicted []string
+	lc := NewCache[string, string]().WithTTL(150 * time.Millisecond).WithOnEvicted(
+		func(key string, value string) {
+			evicted = append(evicted, key, value)
+		})
+
+	lc.Set("key1", "val1", 0)
+
+	time.Sleep(100 * time.Millisecond) // not enough to expire
+	lc.DeleteExpired()
+	assert.Equal(t, 1, lc.Len())
+
+	v, ok := lc.Get("key1")
+	assert.Equal(t, "val1", v)
+	assert.True(t, ok)
+
+	time.Sleep(200 * time.Millisecond) // expire
+	lc.DeleteExpired()
+	v, ok = lc.Get("key1")
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
+
+	assert.Equal(t, 0, lc.Len())
+	assert.Equal(t, []string{"key1", "val1"}, evicted)
+
+	// add new entry
+	lc.Set("key2", "val2", 0)
+	assert.Equal(t, 1, lc.Len())
+
+	// nothing deleted
+	lc.DeleteExpired()
+	assert.Equal(t, 1, lc.Len())
+	assert.Equal(t, []string{"key1", "val1"}, evicted)
+
+	// Purge, cache should be clean
+	lc.Purge()
+	assert.Equal(t, 0, lc.Len())
+	assert.Equal(t, []string{"key1", "val1", "key2", "val2"}, evicted)
+}
+
+func TestCacheExpired(t *testing.T) {
+	lc := NewCache[string, string]().WithTTL(time.Millisecond * 5)
+
+	lc.Set("key1", "val1", 0)
+	assert.Equal(t, 1, lc.Len())
+
+	v, ok := lc.Peek("key1")
+	assert.Equal(t, v, "val1")
+	assert.True(t, ok)
+
+	v, ok = lc.Get("key1")
+	assert.Equal(t, v, "val1")
+	assert.True(t, ok)
+
+	time.Sleep(time.Millisecond * 10) // wait for entry to expire
+	assert.Equal(t, 1, lc.Len())      // but not purged
+
+	v, ok = lc.Peek("key1")
+	assert.Equal(t, "val1", v, "expired and marked as such, but value is available")
+	assert.False(t, ok)
+
+	v, ok = lc.Get("key1")
+	assert.Equal(t, "val1", v, "expired and marked as such, but value is available")
+	assert.False(t, ok)
+
+	assert.Empty(t, lc.Values())
+}
+
+func TestCache_GetExpiration(t *testing.T) {
+	lc := NewCache[string, string]().WithTTL(time.Second * 5)
+
+	lc.Set("key1", "val1", time.Second*5)
+	assert.Equal(t, 1, lc.Len())
+
+	exp, ok := lc.GetExpiration("key1")
+	assert.True(t, ok)
+	assert.True(t, exp.After(time.Now().Add(time.Second*4)))
+	assert.True(t, exp.Before(time.Now().Add(time.Second*6)))
+
+	lc.Set("key2", "val2", time.Second*10)
+	assert.Equal(t, 2, lc.Len())
+
+	exp, ok = lc.GetExpiration("key2")
+	assert.True(t, ok)
+	assert.True(t, exp.After(time.Now().Add(time.Second*9)))
+	assert.True(t, exp.Before(time.Now().Add(time.Second*11)))
+
+	exp, ok = lc.GetExpiration("non-existing-key")
+	assert.False(t, ok)
+	assert.Zero(t, exp)
+}

--- a/v3/cache_test.go
+++ b/v3/cache_test.go
@@ -175,47 +175,6 @@ func TestCacheNoPurge(t *testing.T) {
 	assert.Equal(t, []string{"key3", "key4", "key1"}, lc.Keys())
 }
 
-func TestCacheWithDeleteExpired(t *testing.T) {
-	var evicted []string
-	lc := NewCache[string, string]().WithTTL(150 * time.Millisecond).WithOnEvicted(
-		func(key string, value string) {
-			evicted = append(evicted, key, value)
-		})
-
-	lc.Set("key1", "val1", 0)
-
-	time.Sleep(100 * time.Millisecond) // not enough to expire
-	lc.DeleteExpired()
-	assert.Equal(t, 1, lc.Len())
-
-	v, ok := lc.Get("key1")
-	assert.Equal(t, "val1", v)
-	assert.True(t, ok)
-
-	time.Sleep(200 * time.Millisecond) // expire
-	lc.DeleteExpired()
-	v, ok = lc.Get("key1")
-	assert.False(t, ok)
-	assert.Equal(t, "", v)
-
-	assert.Equal(t, 0, lc.Len())
-	assert.Equal(t, []string{"key1", "val1"}, evicted)
-
-	// add new entry
-	lc.Set("key2", "val2", 0)
-	assert.Equal(t, 1, lc.Len())
-
-	// nothing deleted
-	lc.DeleteExpired()
-	assert.Equal(t, 1, lc.Len())
-	assert.Equal(t, []string{"key1", "val1"}, evicted)
-
-	// Purge, cache should be clean
-	lc.Purge()
-	assert.Equal(t, 0, lc.Len())
-	assert.Equal(t, []string{"key1", "val1", "key2", "val2"}, evicted)
-}
-
 func TestCache_Values(t *testing.T) {
 	lc := NewCache[string, string]().WithMaxKeys(3)
 
@@ -301,58 +260,6 @@ func TestCacheInvalidateAndEvict(t *testing.T) {
 	assert.False(t, ok)
 	assert.False(t, lc.Remove("key3"))
 	assert.Zero(t, lc.Len())
-}
-
-func TestCacheExpired(t *testing.T) {
-	lc := NewCache[string, string]().WithTTL(time.Millisecond * 5)
-
-	lc.Set("key1", "val1", 0)
-	assert.Equal(t, 1, lc.Len())
-
-	v, ok := lc.Peek("key1")
-	assert.Equal(t, v, "val1")
-	assert.True(t, ok)
-
-	v, ok = lc.Get("key1")
-	assert.Equal(t, v, "val1")
-	assert.True(t, ok)
-
-	time.Sleep(time.Millisecond * 10) // wait for entry to expire
-	assert.Equal(t, 1, lc.Len())      // but not purged
-
-	v, ok = lc.Peek("key1")
-	assert.Equal(t, "val1", v, "expired and marked as such, but value is available")
-	assert.False(t, ok)
-
-	v, ok = lc.Get("key1")
-	assert.Equal(t, "val1", v, "expired and marked as such, but value is available")
-	assert.False(t, ok)
-
-	assert.Empty(t, lc.Values())
-}
-
-func TestCache_GetExpiration(t *testing.T) {
-	lc := NewCache[string, string]().WithTTL(time.Second * 5)
-
-	lc.Set("key1", "val1", time.Second*5)
-	assert.Equal(t, 1, lc.Len())
-
-	exp, ok := lc.GetExpiration("key1")
-	assert.True(t, ok)
-	assert.True(t, exp.After(time.Now().Add(time.Second*4)))
-	assert.True(t, exp.Before(time.Now().Add(time.Second*6)))
-
-	lc.Set("key2", "val2", time.Second*10)
-	assert.Equal(t, 2, lc.Len())
-
-	exp, ok = lc.GetExpiration("key2")
-	assert.True(t, ok)
-	assert.True(t, exp.After(time.Now().Add(time.Second*9)))
-	assert.True(t, exp.Before(time.Now().Add(time.Second*11)))
-
-	exp, ok = lc.GetExpiration("non-existing-key")
-	assert.False(t, ok)
-	assert.Zero(t, exp)
 }
 
 func TestCacheRemoveOldest(t *testing.T) {

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-pkgz/expirable-cache/v3
 
-go 1.20
+go 1.23
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
## Summary
- Replace wall-clock sleeps with `testing/synctest` fake clock in v3 expiry tests
- Use build tags to keep both variants:
  - `cache_expire_test.go` (`!go1.25`): original `time.Sleep`-based tests for Go < 1.25
  - `cache_expire_synctest_test.go` (`go1.25`): deterministic synctest-based tests for Go 1.25+
- Bump `v3/go.mod` from `go 1.20` to `go 1.23` (required for sync timer channels used by synctest)
- Bump v3 CI to Go 1.25 (where `testing/synctest` is stable)
- v1 and v2 remain unchanged on `go 1.20`

### Tests rewritten (v3 only)
- `TestCacheWithDeleteExpired`
- `TestCacheExpired`
- `TestCache_GetExpiration`

Addresses #24